### PR TITLE
some performance optimizations

### DIFF
--- a/priv/vmq_server.schema
+++ b/priv/vmq_server.schema
@@ -803,6 +803,22 @@
                                                                       {datatype, flag}
                                                                      ]}.
 
+%% @doc specifies how many messages we store in the outgoing rpc queue in case 
+%% the remote node is not available
+{mapping, "max_outgoing_publish_queue_size", "vmq_server.max_outgoing_publish_queue_size", [
+                                                                                            {default, 1000},
+                                                                                            {datatype, integer},
+                                                                                            hidden
+                                                                                           ]}.
+
+%% @doc if a cluster node comes back online and we queued messages for this node
+%% we send them in batches. this specifies the size of the batch.
+{mapping, "outgoing_publish_batch_size", "vmq_server.outgoing_publish_batch_size", [
+                                                                                    {default, 20},
+                                                                                    {datatype, integer},
+                                                                                    hidden
+                                                                                   ]}.
+
 {translation, "vmq_server.reg_views",
  fun(Conf) ->
          S = cuttlefish:conf_get("reg_views", Conf),

--- a/priv/vmq_server.schema
+++ b/priv/vmq_server.schema
@@ -851,6 +851,20 @@
                                                            hidden
                                                           ]}.
 
+%% the setup utility will call hooks to create the default directories,
+%% however the setup defaults e.g. data.<nodename> are not matching with our 
+%% defaults, so we need to override them.
+{mapping, "setup.log_dir", "setup.log_dir", [
+                                             {default, "{{platform_log_dir}}/"},
+                                             {datatype, directory},
+                                             hidden
+                                            ]}.
+{mapping, "setup.data_dir", "setup.data_dir", [
+                                             {default, "{{platform_data_dir}}/"},
+                                             {datatype, directory},
+                                             hidden
+                                            ]}.
+
 {translation, "vmq_server.tcp_listen_options", 
  fun(Conf) ->
          S = cuttlefish:conf_get("tcp_listen_options", Conf),

--- a/rebar.lock
+++ b/rebar.lock
@@ -64,7 +64,7 @@
   0},
  {<<"plumtree">>,
   {git,"git://github.com/dergraf/plumtree.git",
-       {ref,"8f73a6fc517d2afced5fd586b4c37673b8894a4a"}},
+       {ref,"0ebc975311eee3610e8105befd325a352a056b15"}},
   0},
  {<<"lager">>,
   {git,"git://github.com/basho/lager.git",

--- a/rebar.lock
+++ b/rebar.lock
@@ -64,7 +64,7 @@
   0},
  {<<"plumtree">>,
   {git,"git://github.com/dergraf/plumtree.git",
-       {ref,"1236aa1022ee8bcfbbc128573608c1d0ff4ed0ea"}},
+       {ref,"8f73a6fc517d2afced5fd586b4c37673b8894a4a"}},
   0},
  {<<"lager">>,
   {git,"git://github.com/basho/lager.git",

--- a/src/vmq_auth.erl
+++ b/src/vmq_auth.erl
@@ -35,21 +35,21 @@ register_hooks() ->
 
 -spec auth_on_register(_, _, _, _, _) -> 'ok'.
 auth_on_register(SrcIp, SubscriberId, User, Password, CleanSession) ->
-    io:format("[~p] auth subscriber ~p from ~p
+    lager:info("[~p] auth subscriber ~p from ~p
               with username ~p and password ~p, cleansession: ~p~n",
               [self(), SubscriberId, SrcIp, User, Password, CleanSession]),
     ok.
 
 -spec auth_on_subscribe(_, _, _) -> 'ok'.
 auth_on_subscribe(User, SubscriberId, Topics) ->
-    io:format("[~p] auth subscriber subscriptions ~p
+    lager:info("[~p] auth subscriber subscriptions ~p
               from ~p with username ~p~n",
               [self(), Topics, SubscriberId, User]),
     ok.
 
 -spec auth_on_publish(_, _, _, _, _, _) -> 'ok'.
 auth_on_publish(User, SubscriberId, MsgRef, Topic, _Payload, _IsRetain) ->
-   io:format("[~p] auth subscriber publish ~p with
+   lager:debug("[~p] auth subscriber publish ~p with
              topic ~p from ~p with username ~p~n",
              [self(), MsgRef, Topic, SubscriberId, User]),
   ok.

--- a/src/vmq_cluster_node.erl
+++ b/src/vmq_cluster_node.erl
@@ -30,9 +30,12 @@
          terminate/2,
          code_change/3]).
 
--record(state, {node, reachable=true, queue = queue:new()}).
+-record(state, {node,
+                reachable=true,
+                queue = queue:new(),
+                batch_size,
+                max_queue_size}).
 -define(REMONITOR, 5000).
--define(BATCH_SIZE, 20).
 
 %%%===================================================================
 %%% API
@@ -49,7 +52,7 @@ start_link(RemoteNode) ->
     gen_server:start_link(?MODULE, [RemoteNode], []).
 
 publish(Pid, Msg) ->
-    case catch gen_server:call(Pid, {publish, Msg}, 100) of
+    case catch gen_server:call(Pid, {publish, Msg}, infinity) of
         ok -> ok;
         {'EXIT', Reason} ->
             % we are not allowed to crash, this would
@@ -87,8 +90,10 @@ publish_batch_single(_Node, Msg) ->
 %% @end
 %%--------------------------------------------------------------------
 init([RemoteNode]) ->
+    MaxQueueSize = vmq_config:get_env(max_outgoing_publish_queue_size),
+    BatchSize = vmq_config:get_env(outgoing_publish_batch_size),
     erlang:monitor_node(RemoteNode, true),
-    {ok, #state{node=RemoteNode}}.
+    {ok, #state{node=RemoteNode, batch_size=BatchSize, max_queue_size=MaxQueueSize}}.
 
 %%--------------------------------------------------------------------
 %% @private
@@ -104,11 +109,18 @@ init([RemoteNode]) ->
 %%                                   {stop, Reason, State}
 %% @end
 %%--------------------------------------------------------------------
-handle_call({publish, Msg}, _From, #state{queue=Q, reachable=true} = State) ->
-    {reply, ok, process_queue(State#state{queue=queue:in(Msg, Q)})};
-handle_call({publish, Msg}, _From, #state{queue=Q, reachable=false} = State) ->
-    {reply, ok, State#state{queue=queue:in(Msg, Q)}}.
-
+handle_call({publish, Msg}, From, #state{queue=Q, reachable=true} = State) ->
+    gen_server:reply(From, ok),
+    {noreply, process_queue(State#state{queue=queue:in(Msg, Q)})};
+handle_call({publish, Msg}, _From, #state{queue=Q, max_queue_size=Max,
+                                          reachable=false} = State) ->
+    case queue:len(Q) < Max of
+        true ->
+            {reply, ok, State#state{queue=queue:in(Msg, Q)}};
+        false ->
+            {reply, {error, outgoing_queue_full}, State}
+    end.
+%%
 %%--------------------------------------------------------------------
 %% @private
 %% @doc
@@ -172,28 +184,29 @@ code_change(_OldVsn, State, _Extra) ->
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
-process_queue(#state{node=Node, queue=Q} = State) ->
+process_queue(#state{node=Node, queue=Q, batch_size=BatchSize} = State) ->
     case queue:is_empty(Q) of
         true -> State;
         false ->
-            State#state{queue=batch(Node, Q)}
+            State#state{queue=batch(Node, BatchSize, Q)}
     end.
 
-batch(Node, Q) ->
-    batch(Node, queue:out(Q), []).
-batch(Node, {{value, V}, Q}, Batch) when length(Batch) < ?BATCH_SIZE ->
-    batch(Node, queue:out(Q), [V|Batch]);
-batch(Node, {{value, V}, Q}, Batch) when length(Batch) == ?BATCH_SIZE ->
+batch(Node, BatchSize, Q) ->
+    batch(Node, BatchSize, queue:out(Q), []).
+
+batch(Node, BatchSize, {{value, V}, Q}, Batch) when length(Batch) < BatchSize ->
+    batch(Node, BatchSize, queue:out(Q), [V|Batch]);
+batch(Node, BatchSize, {{value, V}, Q}, Batch) when length(Batch) == BatchSize ->
     Msgs = lists:reverse([V|Batch]),
     case rpc:call(Node, ?MODULE, publish_batch, [Msgs]) of
         ok ->
-            batch(Node, queue:out(Q), []);
+            batch(Node, BatchSize, queue:out(Q), []);
         {badrpc, _} ->
             lists:foldl(fun(Item, AccQ) ->
                                 queue:in_r(Item, AccQ)
                         end, Q, Batch)
     end;
-batch(Node, {empty, Q} , Batch) ->
+batch(Node, _, {empty, Q} , Batch) ->
     Msgs = lists:reverse(Batch),
     case rpc:call(Node, ?MODULE, publish_batch, [Msgs]) of
         ok ->

--- a/src/vmq_ranch.erl
+++ b/src/vmq_ranch.erl
@@ -32,8 +32,6 @@
              bytes_recv={os:timestamp(), 0},
              bytes_send={os:timestamp(), 0}}).
 
--define(HIBERNATE_AFTER, 5000).
-
 %% API.
 start_link(Ref, Socket, Transport, Opts) ->
     Pid = proc_lib:spawn_link(?MODULE, init, [Ref, Socket, Transport, Opts]),
@@ -95,9 +93,6 @@ loop_(#st{pending=[]} = State) ->
     receive
         M ->
             loop_(handle_message(M, State))
-    after
-        ?HIBERNATE_AFTER ->
-            erlang:hibernate(?MODULE, loop, [State])
     end;
 loop_(#st{} = State) ->
     receive
@@ -249,15 +244,15 @@ handle_message(restart_work, #st{throttled=true} = State) ->
 handle_message(Msg, State) ->
     {exit, {unknown_message_type, Msg}, State}.
 
-maybe_throttle(#st{cpulevel=1} = State) ->
-    erlang:send_after(10, self(), active_once),
-    State#st{throttled=true};
-maybe_throttle(#st{cpulevel=2} = State) ->
-    erlang:send_after(20, self(), active_once),
-    State#st{throttled=true};
-maybe_throttle(#st{cpulevel=L} = State) when L > 2->
-    erlang:send_after(100, self(), active_once),
-    State#st{throttled=true};
+%maybe_throttle(#st{cpulevel=1} = State) ->
+%    erlang:send_after(10, self(), active_once),
+%    State#st{throttled=true};
+%maybe_throttle(#st{cpulevel=2} = State) ->
+%    erlang:send_after(20, self(), active_once),
+%    State#st{throttled=true};
+%maybe_throttle(#st{cpulevel=L} = State) when L > 2->
+%    erlang:send_after(100, self(), active_once),
+%    State#st{throttled=true};
 maybe_throttle(#st{socket=Socket} = State) ->
     case active_once(Socket) of
         ok ->

--- a/src/vmq_ranch.erl
+++ b/src/vmq_ranch.erl
@@ -28,7 +28,6 @@
              proto_tag,
              pending=[],
              throttled=false,
-             cpulevel=0,
              bytes_recv={os:timestamp(), 0},
              bytes_send={os:timestamp(), 0}}).
 
@@ -188,25 +187,29 @@ process_bytes(SessionPid, Bytes, ParserState) ->
 
 handle_message({Proto, _, Data}, #st{proto_tag={Proto, _, _}} = State) ->
     #st{session=SessionPid,
+        socket=Socket,
         parser_state=ParserState,
-        bytes_recv={TS, V},
-        cpulevel=CpuLevel} = State,
+        bytes_recv={TS, V}} = State,
     case process_bytes(SessionPid, Data, ParserState) of
         {ok, NewParserState} ->
             {M, S, _} = TS,
             NrOfBytes = byte_size(Data),
             BytesRecvLastSecond = V + NrOfBytes,
-            {NewCpuLevel, NewBytesRecv} =
+            NewBytesRecv =
             case os:timestamp() of
                 {M, S, _} = NewTS ->
-                    {CpuLevel, {NewTS, BytesRecvLastSecond}};
+                    {NewTS, BytesRecvLastSecond};
                 NewTS ->
                     _ = vmq_exo:incr_bytes_received(BytesRecvLastSecond),
-                    {vmq_sysmon:cpu_load_level(), {NewTS, 0}}
+                    {NewTS, 0}
             end,
-            maybe_throttle(State#st{parser_state=NewParserState,
-                                    bytes_recv=NewBytesRecv,
-                                    cpulevel=NewCpuLevel});
+            case active_once(Socket) of
+                ok ->
+                    State#st{parser_state=NewParserState,
+                             bytes_recv=NewBytesRecv};
+                {error, Reason} ->
+                    {exit, Reason, State}
+            end;
         {throttled, HoldBackBuf} ->
             erlang:send_after(1000, self(), restart_work),
             State#st{throttled=true, buffer=HoldBackBuf};
@@ -231,35 +234,11 @@ handle_message({inet_reply, _, ok}, State) ->
     State;
 handle_message({inet_reply, _, Status}, State) ->
     {exit, {send_failed, Status}, State};
-handle_message(active_once, #st{socket=Socket, throttled=true} = State) ->
-    case active_once(Socket) of
-        ok ->
-            State#st{throttled=false};
-        {error, Reason} ->
-            {exit, Reason, State}
-    end;
 handle_message(restart_work, #st{throttled=true} = State) ->
     #st{proto_tag={Proto, _, _}, buffer=Data, socket=Socket} = State,
     handle_message({Proto, Socket, Data}, State#st{throttled=false, buffer= <<>>});
 handle_message(Msg, State) ->
     {exit, {unknown_message_type, Msg}, State}.
-
-%maybe_throttle(#st{cpulevel=1} = State) ->
-%    erlang:send_after(10, self(), active_once),
-%    State#st{throttled=true};
-%maybe_throttle(#st{cpulevel=2} = State) ->
-%    erlang:send_after(20, self(), active_once),
-%    State#st{throttled=true};
-%maybe_throttle(#st{cpulevel=L} = State) when L > 2->
-%    erlang:send_after(100, self(), active_once),
-%    State#st{throttled=true};
-maybe_throttle(#st{socket=Socket} = State) ->
-    case active_once(Socket) of
-        ok ->
-            State;
-        {error, Reason} ->
-            {exit, Reason, State}
-    end.
 
 send_frames([Frame|Frames], #st{pending=Pending} = State) ->
     Bin = vmq_parser:serialise(Frame),

--- a/src/vmq_reg.erl
+++ b/src/vmq_reg.erl
@@ -324,7 +324,7 @@ publish(SubscriberId, Msg, QoS, not_found) ->
     vmq_msg_store:defer_deliver(SubscriberId, QoS, RefedMsg#vmq_msg.msg_ref),
     RefedMsg;
 publish(SubscriberId, Msg, 0, [QPid|Rest]) ->
-    _ = vmq_queue:enqueue(QPid, {deliver, 0, Msg}),
+    _ = vmq_queue:enqueue_nb(QPid, {deliver, 0, Msg}),
     publish(SubscriberId, Msg, 0, Rest);
 publish(SubscriberId, Msg, QoS, [QPid|Rest]) ->
     RefedMsg = vmq_msg_store:store(SubscriberId, Msg),

--- a/src/vmq_reg_trie.erl
+++ b/src/vmq_reg_trie.erl
@@ -37,11 +37,20 @@ start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 fold(MP, Topic, FoldFun, Acc) when is_list(Topic) ->
-    fold_(FoldFun, Acc, match(MP, Topic)).
+    fold_(MP, FoldFun, Acc, match(MP, Topic)).
 
-fold_(FoldFun, Acc, [Topic|MatchedTopics]) ->
-    fold_(FoldFun, FoldFun(Topic, Acc), MatchedTopics);
-fold_(_, Acc, []) -> Acc.
+fold_(MP, FoldFun, Acc, [{Topic, Node}|MatchedTopics]) when Node == node() ->
+    fold_(MP, FoldFun,
+          fold__(FoldFun, Acc,
+                 ets:lookup(vmq_trie_subs, {MP, Topic})),
+          MatchedTopics);
+fold_(MP, FoldFun, Acc, [{_Topic, Node}|MatchedTopics]) ->
+    fold_(MP, FoldFun, FoldFun(Node, Acc), MatchedTopics);
+fold_(_, _, Acc, []) -> Acc.
+
+fold__(FoldFun, Acc, [{_, SubsIdQoS}|Rest]) ->
+    fold__(FoldFun, FoldFun(SubsIdQoS, Acc), Rest);
+fold__(_, Acc, []) -> Acc.
 
 
 %%%===================================================================
@@ -65,6 +74,7 @@ init([]) ->
     _ = ets:new(vmq_trie, [{keypos, 2}|DefaultETSOpts]),
     _ = ets:new(vmq_trie_node, [{keypos, 2}|DefaultETSOpts]),
     _ = ets:new(vmq_trie_topic, [bag, {keypos, 1}|DefaultETSOpts]),
+    _ = ets:new(vmq_trie_subs, [bag|DefaultETSOpts]),
     Self = self(),
     spawn_link(
       fun() ->
@@ -158,15 +168,17 @@ code_change(_OldVsn, State, _Extra) ->
 %%%===================================================================
 handle_event(Handler, Event) ->
     case Handler(Event) of
-        {subscribe, MP, Topic, {_, _, _}} ->
+        {subscribe, MP, Topic, {SubscriberId, QoS, _}} ->
             %% subscribe on local node
-            add_topic(MP, Topic, node());
+            add_topic(MP, Topic, node()),
+            add_subscriber(MP, Topic, SubscriberId, QoS);
         {subscribe, MP, Topic, Node} when is_atom(Node) ->
             %% subscribe on remote node
             add_topic(MP, Topic, Node);
-        {unsubscribe, MP, Topic, {_, _}} ->
+        {unsubscribe, MP, Topic, {SubscriberId, QoS}} ->
             %% unsubscribe on local node
-            del_topic(MP, Topic, node());
+            del_topic(MP, Topic, node()),
+            del_subscriber(MP, Topic, SubscriberId, QoS);
         {unsubscribe, MP, Topic, Node} when is_atom(Node) ->
             %% unsubscribe on remote node
             del_topic(MP, Topic, Node);
@@ -195,8 +207,9 @@ match_(Topic, [{_, Node}|Rest], Acc) ->
     match_(Topic, Rest, [{Topic, Node}|Acc]);
 match_(_, [], Acc) -> Acc.
 
-initialize_trie({MP, Topic, {_,_,_}}, Acc) ->
+initialize_trie({MP, Topic, {SubscriberId, QoS, _}}, Acc) ->
     add_topic(MP, Topic, node()),
+    add_subscriber(MP, Topic, SubscriberId, QoS),
     Acc;
 initialize_trie({MP, Topic, Node}, Acc) when is_atom(Node) ->
     add_topic(MP, Topic, Node),
@@ -296,3 +309,9 @@ trie_delete_path(MP, [{Node, Word, _}|RestPath]) ->
             lager:debug("NodeId ~p not found", [NodeId]),
             ignore
     end.
+
+add_subscriber(MP, Topic, SubscriberId, QoS) ->
+    ets:insert(vmq_trie_subs, {{MP, Topic}, {SubscriberId, QoS}}).
+
+del_subscriber(MP, Topic, SubscriberId, QoS) ->
+    ets:delete_object(vmq_trie_subs, {{MP, Topic}, {SubscriberId, QoS}}).

--- a/src/vmq_server.app.src
+++ b/src/vmq_server.app.src
@@ -37,6 +37,8 @@
       {vmq_config_enabled, true},
       {default_reg_view, vmq_reg_trie},
       {reg_views, [vmq_reg_trie]},
+      {max_outgoing_publish_queue_size, 1000},
+      {outgoing_publish_batch_size, 20},
       {listeners, [{mqtt, [
                          %  {{{127,0,0,1}, 1888}, [{max_connections, infinity}, 
                          %                     {mountpoint, ""}]}

--- a/src/vmq_server.erl
+++ b/src/vmq_server.erl
@@ -41,6 +41,9 @@ start() ->
     _ = application:load(plumtree),
     application:set_env(plumtree, plumtree_data_dir, "./data/" ++ atom_to_list(node())),
     application:set_env(plumtree, storage_mod, plumtree_leveldb_metadata_manager),
+    _ = application:load(setup),
+    application:set_env(setup, log_dir, "./log"),
+    application:set_env(setup, data_dir, "./data"),
     start_no_auth(),
     vmq_auth:register_hooks().
 

--- a/src/vmq_server_sup.erl
+++ b/src/vmq_server_sup.erl
@@ -47,6 +47,7 @@ init([]) ->
             ?CHILD(vmq_config, worker, []),
             ?CHILD(vmq_crl_srv, worker, []),
             ?CHILD(vmq_sysmon, worker, []),
+            ?CHILD(vmq_exo, worker, []),
             ?CHILD(vmq_session_proxy_sup, supervisor, []),
             ?CHILD(vmq_msg_store_sup, supervisor, []),
             ?CHILD(vmq_reg_sup, supervisor, []),

--- a/test/vmq_cluster_SUITE.erl
+++ b/test/vmq_cluster_SUITE.erl
@@ -199,6 +199,7 @@ receive_publishes(Nodes, Topic, Payloads) ->
         {ok, #mqtt_publish{message_id=MsgId, payload=Payload}} ->
             ok = gen_tcp:send(Socket, packet:gen_puback(MsgId)),
             ok = gen_tcp:send(Socket, Disconnect),
+            gen_tcp:close(Socket),
             io:format(user, "+", []),
             receive_publishes(Nodes, Topic, Payloads -- [Payload]);
         {error, _} ->

--- a/test/vmq_netsplit_subscribe_SUITE.erl
+++ b/test/vmq_netsplit_subscribe_SUITE.erl
@@ -44,7 +44,8 @@ subscribe_clean_session_test(Config) ->
     Connack = packet:gen_connack(0),
     Subscribe = packet:gen_subscribe(53, "netsplit/0/test", 0),
     Suback = packet:gen_suback(53, 0),
-    Port = vmq_netsplit_utils:get_port(Nodes),
+    Port = vmq_netsplit_utils:get_port(Nodes), % port for first node
+    [FirstNode|_] = Nodes,
     {ok, Socket} = packet:do_client_connect(Connect, Connack,
                                             [{port, Port}]),
 
@@ -66,7 +67,7 @@ subscribe_clean_session_test(Config) ->
                                                     subscriptions_for_subscriber_id,
                                                     [{"", "test-netsplit-client"}]),
     ct:pal("subscrptions on island 1: ~p", [Island1Res]),
-    Island1Res = [[{"netsplit/0/test", 0}] || _ <- lists:seq(1, length(Island1))],
+    Island1Res = [[{"netsplit/0/test", 0, FirstNode}] || _ <- lists:seq(1, length(Island1))],
     Island2Res = vmq_netsplit_utils:proxy_multicall(Island2, vmq_reg,
                                                     subscriptions_for_subscriber_id,
                                                     [{"", "test-netsplit-client"}]),
@@ -94,4 +95,4 @@ subscribe_clean_session_test(Config) ->
     NodesRes = vmq_netsplit_utils:proxy_multicall(Nodes, vmq_reg,
                                                   subscriptions_for_subscriber_id,
                                                   [{"", "test-netsplit-client"}]),
-    NodesRes = [[{"netsplit/0/test", 0}] || _ <- lists:seq(1, length(Nodes))].
+    NodesRes = [[{"netsplit/0/test", 0, FirstNode}] || _ <- lists:seq(1, length(Nodes))].

--- a/test/vmq_publish_SUITE.erl
+++ b/test/vmq_publish_SUITE.erl
@@ -410,4 +410,5 @@ helper_pattern_matching(PubTopic) ->
     Publish = packet:gen_publish(PubTopic, 0, <<"message">>, [{retain, true}]),
     {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
     ok = gen_tcp:send(Socket, Publish),
+    ok = gen_tcp:send(Socket, packet:gen_disconnect()),
     gen_tcp:close(Socket).


### PR DESCRIPTION
- using exometer counters instead of probes
- removed unnecessary timers
  1. no timed hibernation anymore (it wasn't necessary in the first place)
  2. no timed counter updated, they are now updated incrementally
  3. removed CPU usage based throttling (this used timers to delay active once)
- inside the publish loop only ETS is touched not plumtree anymore
- changed key/value structure of the plumtree metadata, (this reduces the memory kept in RAM by LevelDB)

Warning:
Using this commit requires to delete the existing metadata (subscriptions)
