### PR TITLE
Update vmq_websocket.erl

### DIFF
--- a/src/vmq_websocket.erl
+++ b/src/vmq_websocket.erl
@@ -32,7 +32,7 @@ init(Req, Opts) ->
         [SubProtocol] ->
             case lists:member(SubProtocol, ?SUPPORTED_PROTOCOLS) of
                 true ->
-                    Req2 = cowboy_req:set_resp_header(<<"sec-websocket-protocol">>, <<"mqttv3.1">>, Req),
+                    Req2 = cowboy_req:set_resp_header(<<"sec-websocket-protocol">>, SubProtocol, Req),
                     init_(Req2, Opts);
                 false ->
                     {stop, Req, undefined}


### PR DESCRIPTION
This change is to support the protocol "mqtt", which is mentioned in this line -define(SUPPORTED_PROTOCOLS, [<<"mqttv3.1">>, <<"mqtt">>]).
