### PR TITLE
Make it build on erlang 18

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,6 +9,8 @@
 {ct_extra_params, "-cover test/cover.spec -epmd_port 4369"}.
 {xref_checks, []}.
 {deps, [
+        %% adding edown at the top to be able to build on Erlang >= 18
+        {edown, {git, "git://github.com/uwiger/edown.git", {tag, "0.7"}}},
         %% adding lager at the top of the deps-list ensures that the
         %% giver version wins against the versions pulled by other deps.
         {lager, {git, "git://github.com/basho/lager.git", {tag, "3.0.1"}}},
@@ -48,9 +50,12 @@
         {vmq_plugin, {git, "git://github.com/erlio/vmq_plugin.git", {branch, "master"}}},
 
         %% simulating netsplits for dummies, only needed in test cases
-        {epmdpxy, {git, "git://github.com/dergraf/epmdpxy", {branch, "master"}}}
+        {epmdpxy, {git, "git://github.com/dergraf/epmdpxy", {branch, "master"}}},
+
+        {time_compat, {git, "git://github.com/lasp-lang/time_compat.git", {branch, "master"}}}
        ]}.
 {overrides, [{override, setup, [{post_hooks, []}]},
+             {override, plumtree, [{erl_opts, [debug_info, {parse_transform, lager_transform}]}]},
              {override, cowboy, [{deps, [{cowlib, {git, "git://github.com/ninenines/cowlib.git", {tag, "1.0.0"}}},
                                          {ranch, {git, "git://github.com/ninenines/ranch.git", {tag, "1.0.0"}}}]}
                                 ]},

--- a/src/vmq_lvldb_store.erl
+++ b/src/vmq_lvldb_store.erl
@@ -108,7 +108,7 @@ call(Key, Req) ->
 %%--------------------------------------------------------------------
 init([InstanceId]) ->
     %% Initialize random seed
-    random:seed(now()),
+    random:seed(os:timestamp()),
 
     Opts = vmq_config:get_env(msg_store_opts, []),
     DataDir1 = proplists:get_value(store_dir, Opts, "data/msgstore"),

--- a/src/vmq_mqtt_fsm.erl
+++ b/src/vmq_mqtt_fsm.erl
@@ -82,7 +82,7 @@
 -define(state_val(Key, Args, State), prop_val(Key, Args, State#state.Key)).
 
 init(Peer, Opts) ->
-    {A, B, C} = now(),
+    {A, B, C} = os:timestamp(),
     random:seed(A, B, C),
     MountPoint = proplists:get_value(mountpoint, Opts, ""),
     PreAuthUser =
@@ -1029,7 +1029,7 @@ msg_ref() ->
     GUID =
     case get(guid) of
         undefined ->
-            {{node(), now()}, 0};
+            {{node(), time_compat:timestamp()}, 0};
         {S, I} ->
             {S, I + 1}
     end,

--- a/src/vmq_queue.erl
+++ b/src/vmq_queue.erl
@@ -329,7 +329,7 @@ init([SubscriberId]) ->
       max_drain_time := DrainTime,
       max_msgs_per_drain_step := MaxMsgsPerDrainStep} = Defaults,
     OfflineQueue = #queue{type=QueueType, max=MaxOfflineMsgs},
-    {A, B, C} = now(),
+    {A, B, C} = os:timestamp(),
     random:seed(A, B, C),
     gen_fsm:send_event(self(), init_offline_queue),
     vmq_exo:incr_inactive_clients(),

--- a/test/vmq_cluster_SUITE.erl
+++ b/test/vmq_cluster_SUITE.erl
@@ -246,7 +246,7 @@ publish(Self, [Node|Rest] = Nodes, NrOfProcesses, NrOfMsgsPerProcess, Pids) ->
     publish(Self, Rest ++ [Node], NrOfProcesses -1, NrOfMsgsPerProcess, [Pid|Pids]).
 
 publish_(Self, Node, NrOfMsgsPerProcess) ->
-    {A, B, C} =  now(),
+    {A, B, C} =  os:timestamp(),
     random:seed(A, B, C),
     publish__(Self, Node, NrOfMsgsPerProcess).
 publish__(Self, _, 0) ->

--- a/test/vmq_lvldb_store_SUITE.erl
+++ b/test/vmq_lvldb_store_SUITE.erl
@@ -30,7 +30,7 @@ end_per_suite(_Config) ->
     _Config.
 
 init_per_testcase(_Case, Config) ->
-    random:seed(now()),
+    random:seed(os:timestamp()),
     vmq_test_utils:setup(),
     Config.
 

--- a/test/vmq_netsplit_utils.erl
+++ b/test/vmq_netsplit_utils.erl
@@ -26,7 +26,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 setup(NetTickTime) ->
-    {A, B, C} = now(),
+    {A, B, C} = os:timestamp(),
     random:seed(A, B, C),
     os:cmd("killall epmd"),
     epmdpxy:start(?DEFAULT_EPMDPXY_PORT),


### PR DESCRIPTION
related to https://github.com/erlio/vernemq/pull/81

I introduced the edown dependency bump here, so if merged it should be removed from vernemq
I introduced time_compat and used it only in one place, to seed the random generator I replaced calls to now() for os:timestamp() which has the same format but is not monotonically increasing, but in case of random number generators I don't think it's a problem.

I only used time_compat:timestamp() on the GUID call since I think it can be a requirement that it's unique.
