### PR TITLE
Fix websocket termination

### DIFF
--- a/priv/vmq_server.schema
+++ b/priv/vmq_server.schema
@@ -1048,7 +1048,7 @@
 }.
 
 {mapping, "tcp_listen_options", "vmq_server.tcp_listen_options", [
-                                                                  {default, "[{packet, raw}, {nodelay, true}, {reuseaddr, true}, {linger, {true, 0}}, {send_timeout, 30000}, {send_timeout_close, true}]"},
+                                                                  {default, "[{nodelay, true}, {linger, {true, 0}}, {send_timeout, 30000}, {send_timeout_close, true}]"},
                                                                   {datatype, string},
                                                                   hidden
                                                                  ]}.

--- a/src/vmq_websocket.erl
+++ b/src/vmq_websocket.erl
@@ -17,7 +17,7 @@
 -export([websocket_init/3]).
 -export([websocket_handle/3]).
 -export([websocket_info/3]).
--export([terminate/3]).
+-export([websocket_terminate/3]).
 
 -record(st, {buffer= <<>>,
              fsm_mod,
@@ -80,10 +80,10 @@ websocket_info({FsmMod, Msg}, Req, #st{fsm_mod=FsmMod, fsm_state=FsmState} = Sta
 websocket_info(_Info, Req, State) ->
     {ok, Req, State}.
 
-terminate(_Reason, _Req, #st{fsm_state=terminated}) ->
+websocket_terminate(_Reason, _Req, #st{fsm_state=terminated}) ->
     _ = vmq_exo:decr_socket_count(),
     ok;
-terminate(_Reason, _Req, #st{fsm_mod=FsmMod, fsm_state=FsmState}) ->
+websocket_terminate(_Reason, _Req, #st{fsm_mod=FsmMod, fsm_state=FsmState}) ->
     _ = FsmMod:msg_in(disconnect, FsmState),
     _ = vmq_exo:decr_socket_count(),
     ok.


### PR DESCRIPTION
Fix the websocket termination issue
Remove `{packet, raw}` and `{reuseaddr, true}` as options to ranch to prevent warnings. These options are default by ranch (please confirm that @dergraf , I couldn't find this on the ranch website).
