### PR TITLE
Can't change Nodename

### DIFF
--- a/src/vmq_reg.erl
+++ b/src/vmq_reg.erl
@@ -59,7 +59,8 @@
 %% used by reg views
 -export([subscribe_subscriber_changes/0,
          fold_subscriptions/2,
-         fold_subscribers/2]).
+         fold_subscribers/2,
+         fold_subscribers/3]).
 %% used by vmq_mqtt_fsm list_sessions
 -export([fold_sessions/2]).
 

--- a/src/vmq_server_sup.erl
+++ b/src/vmq_server_sup.erl
@@ -44,6 +44,8 @@ init([]) ->
     {ok, PlumtreeJobsOpts} = application:get_env(vmq_server, plumtree_jobs_opts),
     {ok, MsgStoreChildSpecs} = application:get_env(vmq_server, msg_store_childspecs),
 
+    maybe_change_nodename(),
+
     ok = jobs:add_queue(plumtree_queue, PlumtreeJobsOpts),
     {ok, { {one_for_one, 5, 10},
            [?CHILD(vmq_config, worker, []) | MsgStoreChildSpecs]
@@ -55,4 +57,37 @@ init([]) ->
                ?CHILD(vmq_reg_sup, supervisor, []),
                ?CHILD(vmq_cluster_node_sup, supervisor, [])
               ]} }.
+
+maybe_change_nodename() ->
+    {ok, LocalState} = plumtree_peer_service_manager:get_local_state(),
+    SubscriberDB = {vmq, subscriber},
+    case riak_dt_orswot:value(LocalState) of
+        [Node] when Node =/= node() ->
+            lager:info("Rename VerneMQ Node", []),
+            {ok, Actor} = plumtree_peer_service_manager:get_actor(),
+            {ok, Merged} = riak_dt_orswot:update({update, [{remove, Node},
+                                                           {add, node()}]}, Actor, LocalState),
+            _ = gen_server:cast(plumtree_peer_service_gossip, {receive_state, Merged}),
+            vmq_reg:fold_subscribers(
+              fun(SubscriberId, Subs, _Acc) ->
+                      NewSubs =
+                      lists:foldl(
+                        fun({_, _, N}, SubsAcc) when N == node() ->
+                                SubsAcc;
+                           ({Topic, QoS, _OldNode}, SubsAcc) ->
+                                [{Topic, QoS, node()}|SubsAcc]
+                        end, [], Subs),
+                      %% writing the changed subscriptions will trigger
+                      %% vmq_reg_mgr to initiate queue migration
+                      plumtree_metadata:put(SubscriberDB, SubscriberId,
+                                            lists:usort(NewSubs))
+              end, ignored, false);
+        _ ->
+            %% we ignore if the node has the same name
+            %% or if more than one node is returned (clustered)
+            ignore
+    end.
+
+
+
 


### PR DESCRIPTION
If a VerneMQ node has been started for the first time it stores its Nodename inside the metadata store. If one change the Nodename in vernemq.conf and restarts the node the cluster isn't available anymore (cluster status Running=false) because it is still looking for a node with the old Nodename. 

A workaround currently exists:
1. Stop the Node
2. Rename the Node (if not already done)
3. Delete the file /var/lib/vernemq/meta/peer_service/cluster_state
4. Restart the Node
5. if needed rejoin the cluster
