### PR TITLE
Set max client_id_size to 100

### DIFF
--- a/priv/vmq_server.schema
+++ b/priv/vmq_server.schema
@@ -115,8 +115,8 @@
 %% @doc Set the maximum size for client IDs. MQTT v3.1 specifies a
 %% limit of 23 characters
 {mapping, "max_client_id_size", "vmq_server.max_client_id_size", [
-                                                               {default, 23},
-                                                               {commented, 23},
+                                                               {default, 100},
+                                                               {commented, 100},
                                                                {datatype, integer}
                                                               ]}.
 

--- a/src/vmq_mqtt_fsm.erl
+++ b/src/vmq_mqtt_fsm.erl
@@ -66,7 +66,7 @@
           %% config
           allow_anonymous=false             :: boolean(),
           mountpoint=""                     :: mountpoint(),
-          max_client_id_size=23             :: non_neg_integer(),
+          max_client_id_size=100            :: non_neg_integer(),
 
           %% changeable by auth_on_register
           max_inflight_messages=20          :: non_neg_integer(), %% 0 means unlimited

--- a/src/vmq_server.app.src
+++ b/src/vmq_server.app.src
@@ -22,7 +22,7 @@
   {env, [
       % session opts
       {allow_anonymous, true},
-      {max_client_id_size, 23},
+      {max_client_id_size, 100},
       {retry_interval, 20},
       {max_inflight_messages, 20},
       {max_message_rate, 0}, % no rate limit


### PR DESCRIPTION
Most clients do not conform to MQTT specs and generate client ids longer
than 23 characters. 100 should suffice for most use cases.
