### PR TITLE
Handle system messages

### DIFF
--- a/src/vmq_ranch.erl
+++ b/src/vmq_ranch.erl
@@ -215,8 +215,7 @@ handle_message({system, From, Request}, State) ->
     %% Not sure if passing the parent as undefined is really allowed,
     %% but process state inspection at least seem to work fine.
     Parent = undefined,
-    sys:handle_system_msg(Request, From, Parent, ?MODULE, [],
-                          {State, 0});
+    sys:handle_system_msg(Request, From, Parent, ?MODULE, [], State);
 handle_message(OtherMsg, #st{fsm_state=FsmState0, fsm_mod=FsmMod, pending=Pending} = State) ->
     case FsmMod:msg_in(OtherMsg, FsmState0) of
         {ok, FsmState1, Out} ->
@@ -294,11 +293,11 @@ port_cmd_({ssl, Socket}, Data) ->
 port_cmd_(Socket, Data) ->
     erlang:port_command(Socket, Data).
 
-system_continue(_, _, {State, _NrOfChildren}) ->
+system_continue(_, _, State) ->
 	loop(State).
 
 -spec system_terminate(any(), _, _, _) -> no_return().
-system_terminate(Reason, _, _, {State, _NrOfChildren}) ->
+system_terminate(Reason, _, _, State) ->
 	teardown(State, Reason).
 
 system_code_change(Misc, _, _, _) ->

--- a/src/vmq_ranch.erl
+++ b/src/vmq_ranch.erl
@@ -22,6 +22,10 @@
 -export([init/4,
          loop/1]).
 
+-export([system_continue/3]).
+-export([system_terminate/4]).
+-export([system_code_change/4]).
+
 -record(st, {socket,
              buffer= <<>>,
              fsm_mod,
@@ -207,6 +211,12 @@ handle_message(restart_work, #st{throttled=true} = State) ->
 handle_message({'EXIT', _Parent, Reason}, #st{fsm_state=FsmState0, fsm_mod=FsmMod} = State) ->
     _ = FsmMod:msg_in(disconnect, FsmState0),
     {exit, Reason, State};
+handle_message({system, From, Request}, State) ->
+    %% Not sure if passing the parent as undefined is really allowed,
+    %% but process state inspection at least seem to work fine.
+    Parent = undefined,
+    sys:handle_system_msg(Request, From, Parent, ?MODULE, [],
+                          {State, 0});
 handle_message(OtherMsg, #st{fsm_state=FsmState0, fsm_mod=FsmMod, pending=Pending} = State) ->
     case FsmMod:msg_in(OtherMsg, FsmState0) of
         {ok, FsmState1, Out} ->
@@ -284,4 +294,12 @@ port_cmd_({ssl, Socket}, Data) ->
 port_cmd_(Socket, Data) ->
     erlang:port_command(Socket, Data).
 
+system_continue(_, _, {State, _NrOfChildren}) ->
+	loop(State).
 
+-spec system_terminate(any(), _, _, _) -> no_return().
+system_terminate(Reason, _, _, {State, _NrOfChildren}) ->
+	teardown(State, Reason).
+
+system_code_change(Misc, _, _, _) ->
+	{ok, Misc}.


### PR DESCRIPTION
Handle system messages so the process state can be inspected using the
sys:handle_system_msg/6 call and system_continue/3 callback.

The system_terminate/4 and system_code_change/4 have been borrowed from
vmq_ranch_sup, it's not clear if we really need them.
