### PR TITLE
Use local ref count table to speed up deletes

### DIFF
--- a/src/vmq_lvldb_store_utils.erl
+++ b/src/vmq_lvldb_store_utils.erl
@@ -17,7 +17,8 @@
 
 %% API
 -export([dump/1,
-         dump/2]).
+         dump/2,
+         full_table_scan/2]).
 
 %%%===================================================================
 %%% API
@@ -30,33 +31,52 @@ dump(FileName) ->
 
 dump(FileName, FileOpenOpts) ->
     {ok, Fd} = file:open(FileName, FileOpenOpts),
-    dump_(vmq_lvldb_store_sup:get_bucket_pids(), Fd).
+    full_table_scan(fun file_dump_/2, Fd),
+    file:close(Fd).
 
-dump_([], Fd) -> file:close(Fd);
-dump_([Pid|Rest], Fd) ->
-    full_table_scan(vmq_lvldb_store:get_ref(Pid), Fd),
-    dump_(Rest, Fd).
+file_dump_({msg, MsgRef, MP, RoutingKey, Payload}, Fd) ->
+    file:write(Fd, io_lib:format("Msg[~s]:\t ref: ~p\t topic: ~s\t data: ~p~n",
+                                 [MP, erlang:phash2(MsgRef),
+                                  iolist_to_binary(vmq_topic:unword(RoutingKey)),
+                                  Payload])),
+    Fd;
+file_dump_({ref, MsgRef, MP, ClientId}, Fd) ->
+    file:write(Fd, io_lib:format("Ref[~s]:\t ref: ~p\t client: ~s~n",
+                                 [MP, erlang:phash2(MsgRef), ClientId])),
+    Fd;
+file_dump_({idx, MsgRef, MP, ClientId, IdxVal}, Fd) ->
+    {{MegaS, Sec, MicroS}, Dup, QoS} = IdxVal,
+    file:write(Fd, io_lib:format("Idx[~s]:\t ref: ~p\t client: ~s\t ts: ~p.~p.~p dup: ~p qos: ~p~n",
+                                 [MP, erlang:phash2(MsgRef), ClientId, MegaS,
+                                  Sec, MicroS, Dup, QoS])),
+    Fd.
 
-full_table_scan(Bucket, Fd) ->
+
+full_table_scan(FoldFun, Acc) ->
+    full_table_scan_(vmq_lvldb_store_sup:get_bucket_pids(), {FoldFun, Acc}).
+
+full_table_scan_([Bucket|Rest], Acc) ->
     FoldOpts = [{fill_cache, false}],
-    eleveldb:fold(Bucket, fun full_table_scan_/2, Fd, FoldOpts).
+    NewAcc = eleveldb:fold(vmq_lvldb_store:get_ref(Bucket), fun full_table_scan__/2, Acc, FoldOpts),
+    full_table_scan_(Rest, NewAcc);
+full_table_scan_([], {_, Acc}) -> Acc.
 
-full_table_scan_({Key, Value}, Fd) ->
+full_table_scan__({Key, Value}, {FoldFun, FoldAcc} = Acc) ->
+    NewFoldAcc =
     case sext:decode(Key) of
         {msg, MsgRef, {MP, ''}} ->
             {RoutingKey, Payload} = binary_to_term(Value),
-            file:write(Fd, io_lib:format("Msg[~s]:\t ref: ~p\t topic: ~s\t data: ~p~n",
-                                         [MP, erlang:phash2(MsgRef),
-                                          iolist_to_binary(vmq_topic:unword(RoutingKey)), Payload]));
+            FoldFun({msg, MsgRef, MP, RoutingKey, Payload}, FoldAcc);
         {msg, MsgRef, {MP, ClientId}} ->
             <<>> = Value,
-            file:write(Fd, io_lib:format("Ref[~s]:\t ref: ~p\t client: ~s~n",
-                                         [MP, erlang:phash2(MsgRef), ClientId]));
+            FoldFun({ref, MsgRef, MP, ClientId}, FoldAcc);
         {idx, {MP, ClientId}, MsgRef} ->
-            {{MegaS, Sec, MicroS}, Dup, QoS} = binary_to_term(Value),
-            file:write(Fd, io_lib:format("Idx[~s]:\t ref: ~p\t client: ~s\t ts: ~p.~p.~p dup: ~p qos: ~p~n",
-                      [MP, erlang:phash2(MsgRef), ClientId, MegaS, Sec, MicroS, Dup, QoS]));
+            IdxVal = binary_to_term(Value),
+            FoldFun({idx, MsgRef, MP, ClientId, IdxVal}, FoldAcc);
         E ->
-            io:format("unknown sext encoded key ~p~n", [E])
+            io:format("unknown sext encoded key ~p~n", [E]),
+            Acc
     end,
-    Fd.
+    {FoldFun, NewFoldAcc}.
+
+

--- a/test/vmq_lvldb_store_SUITE.erl
+++ b/test/vmq_lvldb_store_SUITE.erl
@@ -47,17 +47,26 @@ all() ->
 %%% Actual Tests
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 insert_delete_test(Config) ->
+    {0,0,0} = store_summary(),
     Msgs = generate_msgs(1000, []),
     Refs = [Ref || #vmq_msg{msg_ref=Ref} <- Msgs],
     ok = store_msgs({"", "foo"}, Msgs),
+
+    {1000,1000,1000} = store_summary(),
+
+    1000 = refcount(Refs, 0),
     %% we should get back the exact same list
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo"}),
     %% delete all
     ok = delete_msgs({"", "foo"}, Msgs),
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo"}),
+
+    0 = refcount(Refs, 0),
+    {0,0,0} = store_summary(),
     Config.
 
 ref_delete_test(Config) ->
+    {0,0,0} = store_summary(),
     Msgs = generate_msgs(1000, []),
     Refs = [Ref || #vmq_msg{msg_ref=Ref} <- Msgs],
     ok = store_msgs({"", "foo0"}, Msgs),
@@ -71,55 +80,89 @@ ref_delete_test(Config) ->
     ok = store_msgs({"", "foo8"}, Msgs),
     ok = store_msgs({"", "foo9"}, Msgs),
 
+    10000 = refcount(Refs, 0),
+    {1000,10000,10000} = store_summary(),
+
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo0"}),
     {ok, Msgs} = read_msgs({"", "foo0"}, Refs),
     ok = delete_msgs({"", "foo0"}, Msgs),
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo0"}),
+
+    9000 = refcount(Refs, 0),
+    {1000,9000,9000} = store_summary(),
 
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo1"}),
     {ok, Msgs} = read_msgs({"", "foo1"}, Refs),
     ok = delete_msgs({"", "foo1"}, Msgs),
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo1"}),
 
+    8000 = refcount(Refs, 0),
+    {1000,8000,8000} = store_summary(),
+
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo2"}),
     {ok, Msgs} = read_msgs({"", "foo2"}, Refs),
     ok = delete_msgs({"", "foo2"}, Msgs),
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo2"}),
+
+    7000 = refcount(Refs, 0),
+    {1000,7000,7000} = store_summary(),
 
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo3"}),
     {ok, Msgs} = read_msgs({"", "foo3"}, Refs),
     ok = delete_msgs({"", "foo3"}, Msgs),
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo3"}),
 
+    6000 = refcount(Refs, 0),
+    {1000,6000,6000} = store_summary(),
+
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo4"}),
     {ok, Msgs} = read_msgs({"", "foo4"}, Refs),
     ok = delete_msgs({"", "foo4"}, Msgs),
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo4"}),
+
+    5000 = refcount(Refs, 0),
+    {1000,5000,5000} = store_summary(),
 
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo5"}),
     {ok, Msgs} = read_msgs({"", "foo5"}, Refs),
     ok = delete_msgs({"", "foo5"}, Msgs),
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo5"}),
 
+    4000 = refcount(Refs, 0),
+    {1000,4000,4000} = store_summary(),
+
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo6"}),
     {ok, Msgs} = read_msgs({"", "foo6"}, Refs),
     ok = delete_msgs({"", "foo6"}, Msgs),
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo6"}),
+
+    3000 = refcount(Refs, 0),
+    {1000,3000,3000} = store_summary(),
 
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo7"}),
     {ok, Msgs} = read_msgs({"", "foo7"}, Refs),
     ok = delete_msgs({"", "foo7"}, Msgs),
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo7"}),
 
+    2000 = refcount(Refs, 0),
+    {1000,2000,2000} = store_summary(),
+
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo8"}),
     {ok, Msgs} = read_msgs({"", "foo8"}, Refs),
     ok = delete_msgs({"", "foo8"}, Msgs),
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo8"}),
 
+    1000 = refcount(Refs, 0),
+    {1000,1000,1000} = store_summary(),
+
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo9"}),
     {ok, Msgs} = read_msgs({"", "foo9"}, Refs),
     ok = delete_msgs({"", "foo9"}, Msgs),
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo9"}),
+
+    0 = refcount(Refs, 0),
+    {0,0,0} = store_summary(),
+
     Config.
 
 
@@ -151,6 +194,10 @@ read_msgs(SId, [Ref|Refs], Acc) ->
     {ok, Msg} = vmq_lvldb_store:msg_store_read(SId, Ref),
     read_msgs(SId, Refs, [Msg|Acc]).
 
+refcount([Ref|Refs], Cnt) ->
+    refcount(Refs, Cnt + vmq_lvldb_store:refcount(Ref));
+refcount([], Cnt) -> Cnt.
+
 
 random_flag() ->
     random:uniform(10) > 5.
@@ -158,4 +205,14 @@ random_flag() ->
 random_qos() ->
     random:uniform(3) - 1.
 
+store_summary() ->
+    vmq_lvldb_store_utils:full_table_scan(
+      fun
+          ({msg, _, _, _, _}, {NumMsgs, NumRefs, NumIdxs}) ->
+              {NumMsgs + 1, NumRefs, NumIdxs};
+          ({ref, _, _, _}, {NumMsgs, NumRefs, NumIdxs}) ->
+              {NumMsgs, NumRefs + 1, NumIdxs};
+          ({idx, _, _, _, _}, {NumMsgs, NumRefs, NumIdxs}) ->
+              {NumMsgs, NumRefs, NumIdxs + 1}
+      end, {0,0,0}).
 


### PR DESCRIPTION
Bashobench using separate delete and put operations (50/50)
 ![Bashobench using separate delete and put operations (50/50)](https://cloud.githubusercontent.com/assets/155396/16709712/b2ef376c-4618-11e6-8e8c-07f89789faa7.png)

Bashobench using  put and delete within same operations
![Bashobench using  put and delete within same operations](https://cloud.githubusercontent.com/assets/155396/16709721/034ef986-4619-11e6-8d3f-455ab55d8cd8.png)
