### PR TITLE
SSL/TLS refactoring

### DIFF
--- a/priv/vmq_server.schema
+++ b/priv/vmq_server.schema
@@ -954,32 +954,6 @@
                                                                                   {datatype, flag},
                                                                                   hidden
                                                                                  ]}. 
-{mapping, "listener.ssl.support_elliptic_curves", "vmq_server.listeners", [
-                                                                           {default, on},
-                                                                           {datatype, flag},
-                                                                           hidden
-                                                                          ]}. 
-{mapping, "listener.ssl.$name.support_elliptic_curves", "vmq_server.listeners", [
-                                                                                 {datatype, flag},
-                                                                                 hidden
-                                                                                ]}. 
-{mapping, "listener.wss.support_elliptic_curves", "vmq_server.listeners", [
-                                                                           {default, on},
-                                                                           {datatype, flag},
-                                                                           hidden
-                                                                          ]}. 
-{mapping, "listener.wss.$name.support_elliptic_curves", "vmq_server.listeners", [
-                                                                                 {datatype, flag},
-                                                                                 hidden
-                                                                                ]}. 
-{mapping, "listener.vmqs.$name.support_elliptic_curves", "vmq_server.listeners", [
-                                                                                 {datatype, flag},
-                                                                                 hidden
-                                                                                ]}. 
-{mapping, "listener.https.$name.support_elliptic_curves", "vmq_server.listeners", [
-                                                                                 {datatype, flag},
-                                                                                 hidden
-                                                                                ]}. 
 
 
 {translation, "vmq_server.listeners", 
@@ -1017,7 +991,7 @@
          ExtMapps = [%% ssl listener specific
                      "cafile", "capath", "certfile", "ciphers", "crlfile",
                      "keyfile", "require_certificate", "tls_version",
-                     "use_identity_as_username", "support_elliptic_curves",
+                     "use_identity_as_username",
                      %% http listener specific
                      "config_mod", "config_fun"
                     ],
@@ -1100,7 +1074,6 @@
          {SSLIPs, SSLRequireCerts} = lists:unzip(F("listener.ssl", "require_certificate", BoolVal)),
          {SSLIPs, SSLVersions} = lists:unzip(F("listener.ssl", "tls_version", AtomVal)),
          {SSLIPs, SSLUseIdents} = lists:unzip(F("listener.ssl", "use_identity_as_username", BoolVal)),
-         {SSLIPs, SSLECSupport} = lists:unzip(F("listener.ssl", "support_elliptic_curves", BoolVal)),
 
          % WSS
          {WS_SSLIPs, WS_SSLCAFiles} = lists:unzip(F("listener.wss", "cafile", StrVal)),
@@ -1112,7 +1085,6 @@
          {WS_SSLIPs, WS_SSLRequireCerts} = lists:unzip(F("listener.wss", "require_certificate", BoolVal)),
          {WS_SSLIPs, WS_SSLVersions} = lists:unzip(F("listener.wss", "tls_version", AtomVal)),
          {WS_SSLIPs, WS_SSLUseIdents} = lists:unzip(F("listener.wss", "use_identity_as_username", BoolVal)),
-         {WS_SSLIPs, WS_SSLECSupport} = lists:unzip(F("listener.wss", "support_elliptic_curves", BoolVal)),
 
          % VMQS
          {VMQ_SSLIPs, VMQ_SSLCAFiles} = lists:unzip(F("listener.vmqs", "cafile", StrVal)),
@@ -1123,7 +1095,6 @@
          {VMQ_SSLIPs, VMQ_SSLKeyFiles} = lists:unzip(F("listener.vmqs", "keyfile", StrVal)),
          {VMQ_SSLIPs, VMQ_SSLRequireCerts} = lists:unzip(F("listener.vmqs", "require_certificate", BoolVal)),
          {VMQ_SSLIPs, VMQ_SSLVersions} = lists:unzip(F("listener.vmqs", "tls_version", AtomVal)),
-         {VMQ_SSLIPs, VMQ_SSLECSupport} = lists:unzip(F("listener.vmqs", "support_elliptic_curves", BoolVal)),
          
          % HTTPS
          {HTTP_SSLIPs, HTTP_SSLCAFiles} = lists:unzip(F("listener.https", "cafile", StrVal)),
@@ -1134,7 +1105,6 @@
          {HTTP_SSLIPs, HTTP_SSLKeyFiles} = lists:unzip(F("listener.https", "keyfile", StrVal)),
          {HTTP_SSLIPs, HTTP_SSLRequireCerts} = lists:unzip(F("listener.https", "require_certificate", BoolVal)),
          {HTTP_SSLIPs, HTTP_SSLVersions} = lists:unzip(F("listener.https", "tls_version", AtomVal)),
-         {HTTP_SSLIPs, HTTP_SSLECSupport} = lists:unzip(F("listener.https", "support_elliptic_curves", BoolVal)),
 
          TCP = lists:zip(TCPIPs, MZip([TCPMaxConns, 
                                        TCPNrOfAcceptors,
@@ -1161,8 +1131,7 @@
                                        SSLKeyFiles, 
                                        SSLRequireCerts, 
                                        SSLVersions, 
-                                       SSLUseIdents, 
-                                       SSLECSupport])),
+                                       SSLUseIdents])),
          WSS = lists:zip(WS_SSLIPs, MZip([WS_SSLMaxConns, 
                                           WS_SSLNrOfAcceptors,
                                           WS_SSLMountPoint,
@@ -1174,8 +1143,7 @@
                                           WS_SSLKeyFiles, 
                                           WS_SSLRequireCerts, 
                                           WS_SSLVersions, 
-                                          WS_SSLUseIdents, 
-                                          WS_SSLECSupport])),
+                                          WS_SSLUseIdents])),
          VMQS = lists:zip(VMQ_SSLIPs, MZip([VMQ_SSLMaxConns, 
                                           VMQ_SSLNrOfAcceptors,
                                           VMQ_SSLMountPoint,
@@ -1186,8 +1154,7 @@
                                           VMQ_SSLCrlFiles, 
                                           VMQ_SSLKeyFiles, 
                                           VMQ_SSLRequireCerts, 
-                                          VMQ_SSLVersions, 
-                                          VMQ_SSLECSupport])), 
+                                          VMQ_SSLVersions])), 
          HTTPS = lists:zip(HTTP_SSLIPs, MZip([HTTP_SSLMaxConns, 
                                           HTTP_SSLNrOfAcceptors,
                                           HTTP_SSLCAFiles, 
@@ -1198,7 +1165,6 @@
                                           HTTP_SSLKeyFiles, 
                                           HTTP_SSLRequireCerts, 
                                           HTTP_SSLVersions, 
-                                          HTTP_SSLECSupport,
                                           HTTP_SSLConfigMod,
                                           HTTP_SSLConfigFun])),
 

--- a/src/vmq_ssl.erl
+++ b/src/vmq_ssl.erl
@@ -42,10 +42,7 @@ extract_cn2([_|Rest]) ->
 extract_cn2([]) -> undefined.
 
 opts(Opts) ->
-    [{cacerts, case proplists:get_value(cafile, Opts) of
-                   undefined -> undefined;
-                   CAFile -> load_cert(CAFile)
-               end},
+    [{cacertfile, proplists:get_value(cafile, Opts)},
      {certfile, proplists:get_value(certfile, Opts)},
      {keyfile, proplists:get_value(keyfile, Opts)},
      {ciphers, ciphersuite_transform(proplists:get_value(ciphers, Opts, []))},
@@ -113,21 +110,6 @@ check_user_state(UserState, Cert) ->
                 false ->
                     {fail, {bad_cert, cert_revoked}}
             end
-    end.
-
--spec load_cert(string()) -> [binary()].
-load_cert(Cert) ->
-    {ok, Bin} = file:read_file(Cert),
-    case filename:extension(Cert) of
-        ".der" ->
-            %% no decoding necessary
-            [Bin];
-        _ ->
-            %% assume PEM otherwise
-            Contents = public_key:pem_decode(Bin),
-            [DER || {Type, DER, Cipher} <-
-                    Contents, Type == 'Certificate',
-                    Cipher == 'not_encrypted']
     end.
 
 ciphers() ->

--- a/src/vmq_ssl.erl
+++ b/src/vmq_ssl.erl
@@ -1,3 +1,17 @@
+%% Copyright 2014 Erlio GmbH Basel Switzerland (http://erl.io)
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
 -module(vmq_ssl).
 -include_lib("public_key/include/public_key.hrl").
 -export([socket_to_common_name/1,
@@ -34,10 +48,7 @@ opts(Opts) ->
                end},
      {certfile, proplists:get_value(certfile, Opts)},
      {keyfile, proplists:get_value(keyfile, Opts)},
-     {ciphers, ciphersuite_transform(
-                 proplists:get_value(support_elliptic_curves, Opts, true),
-                 proplists:get_value(ciphers, Opts, [])
-                )},
+     {ciphers, ciphersuite_transform(proplists:get_value(ciphers, Opts, []))},
      {fail_if_no_peer_cert, proplists:get_value(require_certificate,
                                                 Opts, false)},
      {verify, case
@@ -64,114 +75,12 @@ opts(Opts) ->
     ].
 
 
--spec ciphersuite_transform(boolean(), string()) -> [{atom(), atom(), atom()}].
-ciphersuite_transform(SupportEC, []) ->
-    unbroken_cipher_suites(all_ciphers(SupportEC));
-ciphersuite_transform(_, CiphersString) when is_list(CiphersString) ->
-    Ciphers = string:tokens(CiphersString, ":"),
-    unbroken_cipher_suites(ciphersuite_transform_(Ciphers, [])).
+-spec ciphersuite_transform([string()]) -> [string()].
+ciphersuite_transform([]) ->
+    ciphers();
+ciphersuite_transform(CiphersString) when is_list(CiphersString) ->
+    CiphersString.
 
--spec ciphersuite_transform_([string()],
-                             [{atom(), atom(), atom()}]) ->
-    [{atom(), atom(), atom()}].
-ciphersuite_transform_([CipherString|Rest], Acc) ->
-    Cipher = string:tokens(CipherString, "-"),
-    case cipher_ex_transform(Cipher) of
-        {ok, CipherSuite} ->
-            ciphersuite_transform_(Rest, [CipherSuite|Acc]);
-        {error, Reason} ->
-            lager:error("error parsing ciphersuite ~p, ~p~n",
-                        [CipherString, Reason]),
-            ciphersuite_transform_(Rest, Acc)
-    end;
-ciphersuite_transform_([], Acc) -> Acc.
-
--spec cipher_ex_transform([string()]) ->
-    {ok, {atom(), atom(), atom()}} |
-    {error, unknown_keyexchange |
-     unknown_cipher | unknown_cipher}.
-cipher_ex_transform(["ECDH", "ANON"|Rest]) ->
-    cipher_ci_transform(ecdh_anon, Rest);
-cipher_ex_transform(["ECDH", "ECDSA"|Rest]) ->
-    cipher_ci_transform(ecdh_ecdsa, Rest);
-cipher_ex_transform(["ECDHE", "ECDSA"|Rest]) ->
-    cipher_ci_transform(ecdhe_ecdsa, Rest);
-cipher_ex_transform(["ECDH", "RSA"|Rest]) ->
-    cipher_ci_transform(ecdh_rsa, Rest);
-cipher_ex_transform(["ECDHE", "RSA"|Rest]) ->
-    cipher_ci_transform(ecdhe_rsa, Rest);
-cipher_ex_transform(["DHE", "DSS"|Rest]) -> cipher_ci_transform(dhe_dss, Rest);
-cipher_ex_transform(["DHE", "RSA"|Rest]) -> cipher_ci_transform(dhe_rsa, Rest);
-cipher_ex_transform(["DH", "ANON"|Rest]) -> cipher_ci_transform(dh_anon, Rest);
-cipher_ex_transform(["DHE", "PSK"|Rest]) -> cipher_ci_transform(dhe_psk, Rest);
-cipher_ex_transform(["RSA", "PSK"|Rest]) -> cipher_ci_transform(rsa_psk, Rest);
-cipher_ex_transform(["SRP", "ANON"|Rest]) ->
-    cipher_ci_transform(srp_anon, Rest);
-cipher_ex_transform(["SRP", "DSS"|Rest]) -> cipher_ci_transform(srp_dss, Rest);
-cipher_ex_transform(["SRP", "RSA"|Rest]) -> cipher_ci_transform(srp_rsa, Rest);
-cipher_ex_transform(["RSA"|Rest]) -> cipher_ci_transform(rsa, Rest);
-cipher_ex_transform(["PSK"|Rest]) -> cipher_ci_transform(psk, Rest);
-cipher_ex_transform([_|Rest]) -> cipher_ex_transform(Rest);
-cipher_ex_transform([]) -> {error, unknown_keyexchange}.
-
--spec cipher_ci_transform(atom(), [string()]) ->
-    {ok, {atom(), atom(), atom()}} |
-    {error, unknown_hash | unknown_cipher}.
-cipher_ci_transform(KeyEx, ["3DES", "EDE", "CBC"|Rest]) ->
-    cipher_hash_transform(KeyEx, '3des_ede_cbc', Rest);
-cipher_ci_transform(KeyEx, ["AES128", "CBC"|Rest]) ->
-    cipher_hash_transform(KeyEx, aes_128_cbc, Rest);
-cipher_ci_transform(KeyEx, ["AES256", "CBC"|Rest]) ->
-    cipher_hash_transform(KeyEx, aes_256_cbc, Rest);
-cipher_ci_transform(KeyEx, ["RC4", "128"|Rest]) ->
-    cipher_hash_transform(KeyEx, rc4_128, Rest);
-cipher_ci_transform(KeyEx, ["DES", "CBC"|Rest]) ->
-    cipher_hash_transform(KeyEx, des_cbc, Rest);
-cipher_ci_transform(KeyEx, [_|Rest]) ->
-    cipher_ci_transform(KeyEx, Rest);
-cipher_ci_transform(_, []) -> {error, unknown_cipher}.
-
--spec cipher_hash_transform(atom(), atom(), [string()]) ->
-    {ok, {atom(), atom(), atom()}} |
-    {error, unknown_hash}.
-cipher_hash_transform(KeyEx, Cipher, ["MD5"]) -> {ok, {KeyEx, Cipher, md5}};
-cipher_hash_transform(KeyEx, Cipher, ["SHA"]) -> {ok, {KeyEx, Cipher, sha}};
-cipher_hash_transform(KeyEx, Cipher, ["SHA256"]) ->
-    {ok, {KeyEx, Cipher, sha256}};
-cipher_hash_transform(KeyEx, Cipher, ["SHA384"]) ->
-    {ok, {KeyEx, Cipher, sha384}};
-cipher_hash_transform(KeyEx, Cipher, [_|Rest]) ->
-    cipher_hash_transform(KeyEx, Cipher, Rest);
-cipher_hash_transform(_, _, []) -> {error, unknown_hash}.
-
--spec all_ciphers(boolean()) -> [{atom(), atom(), atom()}].
-all_ciphers(UseEc) ->
-    ECExchanges = [ecdh_anon, ecdh_ecdsa, ecdhe_ecdsa, ecdh_rsa, ecdhe_rsa],
-    lists:foldl(fun({Ex, _, _} = CS, Acc) ->
-                        case UseEc of
-                            true -> [CS|Acc];
-                            false ->
-                                case lists:member(Ex, ECExchanges) of
-                                    true -> Acc;
-                                    false -> [CS|Acc]
-                                end
-                        end;
-                   (_, Acc) -> Acc
-                end, [], ssl:cipher_suites()).
-
--spec unbroken_cipher_suites([atom()]) -> [{atom(), atom(), atom()}].
-unbroken_cipher_suites(CipherSuites) ->
-    %% from ranch
-    case proplists:get_value(ssl_app, ssl:versions()) of
-        Version when Version =:= "5.3"; Version =:= "5.3.1" ->
-            lists:filter(fun(Suite) ->
-                                 string:left(
-                                   atom_to_list(element(1,
-                                                        Suite)), 4) =/= "ecdh"
-                         end, CipherSuites);
-        _ ->
-            CipherSuites
-    end.
 
 -spec verify_ssl_peer(_, 'valid' | 'valid_peer' |
                       {'bad_cert', _} |
@@ -221,4 +130,41 @@ load_cert(Cert) ->
                     Cipher == 'not_encrypted']
     end.
 
-
+ciphers() ->
+    ["ECDHE-ECDSA-AES256-GCM-SHA384"
+     ,"ECDHE-RSA-AES256-GCM-SHA384"
+     ,"ECDHE-ECDSA-AES256-SHA384"
+     ,"ECDHE-RSA-AES256-SHA384"
+     ,"ECDHE-ECDSA-DES-CBC3-SHA"
+     ,"ECDH-ECDSA-AES256-GCM-SHA384"
+     ,"ECDH-RSA-AES256-GCM-SHA384"
+     ,"ECDH-ECDSA-AES256-SHA384"
+     ,"ECDH-RSA-AES256-SHA384"
+     ,"DHE-DSS-AES256-GCM-SHA384"
+     ,"DHE-DSS-AES256-SHA256"
+     ,"AES256-GCM-SHA384"
+     ,"AES256-SHA256"
+     ,"ECDHE-ECDSA-AES128-GCM-SHA256"
+     ,"ECDHE-RSA-AES128-GCM-SHA256"
+     ,"ECDHE-ECDSA-AES128-SHA256"
+     ,"ECDHE-RSA-AES128-SHA256"
+     ,"ECDH-ECDSA-AES128-GCM-SHA256"
+     ,"ECDH-RSA-AES128-GCM-SHA256"
+     ,"ECDH-ECDSA-AES128-SHA256"
+     ,"ECDH-RSA-AES128-SHA256"
+     ,"DHE-DSS-AES128-GCM-SHA256"
+     ,"DHE-DSS-AES128-SHA256"
+     ,"AES128-GCM-SHA256"
+     ,"AES128-SHA256"
+     ,"ECDHE-ECDSA-AES256-SHA"
+     ,"ECDHE-RSA-AES256-SHA"
+     ,"DHE-DSS-AES256-SHA"
+     ,"ECDH-ECDSA-AES256-SHA"
+     ,"ECDH-RSA-AES256-SHA"
+     ,"AES256-SHA"
+     ,"ECDHE-ECDSA-AES128-SHA"
+     ,"ECDHE-RSA-AES128-SHA"
+     ,"DHE-DSS-AES128-SHA"
+     ,"ECDH-ECDSA-AES128-SHA"
+     ,"ECDH-RSA-AES128-SHA"
+     ,"AES128-SHA"].


### PR DESCRIPTION
- Change default cipher suites (from http://ezgr.net/increasing-security-erlang-ssl-cowboy/)
- Let the SSL application load the cacert chain via the `cacertfile` option instead of our own `load_cert` call
